### PR TITLE
Update default TLD from .dev to .test ... because Google.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.11.1.tgz \
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY run.sh /run.sh
 
-ENV DNS_DOMAIN="dev"
+ENV DNS_DOMAIN="test"
 ENV EXTRA_HOSTS=""
 ENV HOSTMACHINE_IP="172.17.0.1"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ add some custom Docker daemon options. The place to put this config varies:
 
 The extra options you'll have to add is
 
-    --dns 172.17.0.1 --dns-search dev
+    --dns 172.17.0.1 --dns-search test
 
 Replace `test` with whatever you set as config for `DNS_DOMAIN`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You will need to add some configuration to your OS resolving mechanism.
 devdns.
 
 #### OSX
-Create a file `/etc/resolver/dev` containing
+Create a file `/etc/resolver/test` containing
 
     nameserver <listen address of devdns>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ configuring local resolving.
 
 The DNS server running in devdns is set to proxy requests for unknown hosts to
 Google's DNS server 8.8.8.8.
-It also adds a wildcard record (normally `*.dev`, see `DNS_DOMAIN` below)
+It also adds a wildcard record (normally `*.test`, see `DNS_DOMAIN` below)
 pointing back at the host machine (bridge IP in Linux), to facilitate
 communication when running a combination of services "inside" and "outside" of
 Docker.
@@ -38,7 +38,7 @@ $ docker run -d --name devdns -p 53:53/udp \
 $ docker run -d --name redis redis
 $ docker run -it --rm \
   --dns=`docker inspect -f "{{ .NetworkSettings.IPAddress }}" devdns` debian \
-  ping redis.dev
+  ping redis.test
 ```
 
 Please note that the `--dns` flag will prepend the given DNS server to the
@@ -137,16 +137,16 @@ Example:
 ```
 # (devdns already running)
 $ docker run -d --name redis_local-V1 redis
-$ dig redis.dev     # resolves to the IP of redis_local-V1
+$ dig redis.test     # resolves to the IP of redis_local-V1
 
 $ docker run -d --name redis_test redis
-$ dig redis.dev     # resolves to the IP of redis_test
+$ dig redis.test     # resolves to the IP of redis_test
 
 $ docker stop redis_test
-$ dig redis.dev     # resolves to the IP of redis_local-V1
+$ dig redis.test     # resolves to the IP of redis_local-V1
 
 $ docker stop redis_local-V1
-$ dig redis.dev     # resolves to the IP of the host machine (default)
+$ dig redis.test     # resolves to the IP of the host machine (default)
 ```
 
 ### NetworkManager on Ubuntu

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The extra options you'll have to add is
 
     --dns 172.17.0.1 --dns-search dev
 
-Replace `dev` with whatever you set as config for `DNS_DOMAIN`.
+Replace `test` with whatever you set as config for `DNS_DOMAIN`.
 
 `172.17.0.1` is the default IP of the Docker bridge, and port 53 on this host
 should be reachable from within all started containers given that you've
@@ -84,7 +84,7 @@ Create a file `/etc/resolver/test` containing
 In OSX, there's a good chance you're using boot2docker, so the listen address
 will probably be the output of `boot2docker ip`.
 Please note that the name of the file created in `/etc/resolver` has to match
-the value of the `DNS_DOMAIN` setting (default "dev").
+the value of the `DNS_DOMAIN` setting (default "test").
 
 
 #### Linux / Ubuntu
@@ -95,19 +95,19 @@ manually using `/etc/network/interfaces`:
 
     auto p3p1
     iface p3p1 inet dhcp
-    dns-search dev
+    dns-search test
     dns-nameservers 127.0.0.1
 
 Alternatively, edit `/etc/dhcp/dhclient.conf` instead. Uncomment or add the
 following line:
 
-    supersede domain-name "dev";
+    supersede domain-name "test";
     prepend domain-name-servers 127.0.0.1;
 
 
 ## Configuration
 
- * `DNS_DOMAIN`: set the local domain used. (default: dev)
+ * `DNS_DOMAIN`: set the local domain used. (default: test)
  * `HOSTMACHINE_IP`: IP address of non-matching queries (default: 172.17.0.1)
  * `EXTRA_HOSTS`: list of extra records to create, space-separated string of
    host=ip pairs. (default: '')

--- a/run.sh
+++ b/run.sh
@@ -24,9 +24,9 @@ get_name(){
   docker inspect -f '{{ .Name }}' "$cid" | sed "s,^/,,"
 }
 get_safe_name(){
-  local name="$1"
+  local name=$(echo "$1" | sed 's/_/-/g')
   # Docker allows _ in names, but other than that same as RFC 1123
-  # We remove everything from "_" and use the result as record.
+  # We change "_" to "-" and use the result as record.
   if [[ ! "$name" =~ ^[a-zA-Z0-9.-]+$ ]]; then
     name="${name%%_*}"
   fi

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-domain="${DNS_DOMAIN:-dev}"
+domain="${DNS_DOMAIN:-test}"
 extrahosts=($EXTRA_HOSTS)
 hostmachineip="${HOSTMACHINE_IP:-172.17.0.1}"
 dnsmasq_pid=""


### PR DESCRIPTION
Change default TLD from "dev" to "test" because of HSTS for .dev on Chrome 63
    
tl;dr:
Google owns .dev and made changes to Chrome that enforces HSTS to .dev domains, which breaks local environments reliant on that TLD.
    
This change swaps .dev for .test as default dev domains, as specified on RFC2606.
    
Info about the change in Chrome:
https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/
https://chromium-review.googlesource.com/c/chromium/src/+/669396/10/net/http/transport_security_state_static.json
    
Info about .dev:
https://icannwiki.org/.dev
    
Info about .test:
https://en.wikipedia.org/wiki/.test
https://tools.ietf.org/html/rfc2606

Additionally, this also swaps "_" for "-" to reduce collision of default docker names
    
Default Docker container names are composed of <adjective>_<person_name>, this causes increased naming collisions, as do container names from docker-compose and docker stack.
    
This change swaps "_" for "-" on container names, allowing a more natural solution for container names.