### PR TITLE
Fix compatibility issue with the latest Docker version to get network…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -67,7 +67,7 @@ del_container_record(){
 }
 set_container_record(){
   local cid="$1"
-  local ip=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' "$cid")
+  local ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$cid")
   local name=$(get_name "$cid")
   local safename=$(get_safe_name "$name")
   local record="${safename}.${domain}"


### PR DESCRIPTION
The latest Docker version provide a different result on docker inspect for the network node.
This is a the right way to get the result with the last Docker version.