### PR TITLE
Add automatic resolv.conf registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ supersede domain-name "test";
 prepend domain-name-servers 127.0.0.1;
 ```
 
+An other solution is mounting `/etc/resolv.conf` file inside container as `/tmp/resolv.conf`:
+```
+docker run -d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /etc/resolv.conf:/tmp/resolv.conf
+``` 
+this will automatically edit configuration adding devdns's IP as system nameserver on container start. 
+You can see this on the first line of `/etc/resolv.conf`:
+```
+nameserver 192.168.16.2 # added by devdns
+```
+this configuration will be automatically removed when container is stopped or killed.
 
 ## Configuration
 

--- a/run.sh
+++ b/run.sh
@@ -56,6 +56,7 @@ set_record(){
   local fpath="${dnsmasq_path}${record}.conf"
   local ip="$2"
   [[ -z "$ip" ]] && return 1
+  [[ "$ip" == "<no value>" ]] && return 1
 
   local infomsg="${GREEN}+ Added ${record} → ${ip}${RESET}"
   if [[ -f "$fpath" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -85,7 +85,7 @@ set_container_record(){
     # if it inherited its network from another container
     [[ -z "$cnetwork" ]] && return 1
   fi
-  local ip=$(docker inspect -f "{{.NetworkSettings.Networks.${cnetwork}.IPAddress}}" "$cid" | head -n1)
+  local ip=$(docker inspect -f "{{with index .NetworkSettings.Networks \"${cnetwork}\"}}{{.IPAddress}}{{end}}" "$cid" | head -n1)
   local name=$(get_name "$cid")
   local safename=$(get_safe_name "$name")
   local record="${safename}.${domain}"


### PR DESCRIPTION
# Fixed
- Fix issue #12 
- Fix docker inspect's template parsing error when network contain hyphens

# Added
- Automatically resolv.conf registration, inspired by https://github.com/mgood/resolvable